### PR TITLE
add a namespace to the service instance name annotation

### DIFF
--- a/roles/provision-cordova-app/templates/mobile-client.yml.j2
+++ b/roles/provision-cordova-app/templates/mobile-client.yml.j2
@@ -3,7 +3,7 @@ kind: MobileClient
 metadata:
     annotations:
         icon: font-icon icon-cordova
-        service_instance_name: {{ service_instance_name.stdout }}
+        aerogear.org/service-instance-name: {{ service_instance_name.stdout }}
     name: {{ appName }}-cordova
     namespace: {{ namespace }}
 spec:


### PR DESCRIPTION
## Description
Update the `service_instance_name` annotation to `aerogear.org/service-instance-name` to be consistent with the other mobile annotations. This change came from this [feedback](https://github.com/openshift/origin-web-common/pull/341#discussion_r196827721) in origin web common.

## Progress
- [x] Change `service_instance_name` annotation to `aerogear.org/service-instance-name`

## Verification

1. Provision an Cordova client from this branch
2. Ensure that it has the annnotation: `aerogear.org/service-instance-name`.

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/AEROGEAR-3363

![image](https://user-images.githubusercontent.com/9078522/41715753-4e7bc470-754c-11e8-8a0c-e604ad9a755e.png)


